### PR TITLE
Add new line after read key

### DIFF
--- a/FluentConsole/Extensions.cs
+++ b/FluentConsole/Extensions.cs
@@ -38,7 +38,9 @@ namespace FluentConsole.Library
             for (var i = 0; i < lineBreaks; i++)
                 NewLine();
 
-            return ReadKey();
+            var key = ReadKey();
+            NewLine();
+            return key;
         }
 
         /// <summary>
@@ -73,7 +75,9 @@ namespace FluentConsole.Library
             for (var i = 0; i < lineBreaks; i++)
                 NewLine();
 
-            ReadKey();
+            var key = ReadKey();
+            NewLine();
+            return key;
         }
     }
 }

--- a/FluentConsole/Extensions.cs
+++ b/FluentConsole/Extensions.cs
@@ -66,7 +66,7 @@ namespace FluentConsole.Library
         /// <param name="color">The color of the text displayed.</param>
         /// <param name="lineBreaks">The number of *additional* line breaks to include after the specified value.</param>
         /// <returns>The key entered while waiting.</returns>
-        public static void WriteLineWait(this object value, ConsoleColor color, int lineBreaks = 0)
+        public static ConsoleKeyInfo WriteLineWait(this object value, ConsoleColor color, int lineBreaks = 0)
         {
             ForegroundColor = color;
             ConsoleWrapper.WriteLine(value);

--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -12,6 +12,10 @@ namespace TestConsole
     {
         static void Main(string[] args)
         {
+            var key = "Press any key to continue...".WriteLineWait();
+
+            $"You pressed the '{key.Key}' key!".WriteLine(1);
+
             FluentConsoleSettings.LineWrapOption = LineWrapOption.Manual;
             FluentConsoleSettings.LineWrapWidth = 25;
 


### PR DESCRIPTION
## New Features

If a newline is *not* entered after a user types a key, subsequent text written to the window is displayed immediately adjacent to the user's input, which is obviously not ideal.

**Example:**

```
var key = "Press any key to continue...".WriteLineWait();
$"You pressed the '{key.Key}' key!".WriteLine();
```

Previously would have resulted in this...

```
Press any key to continue...
qYou pressed the 'Q' key!
```

But now will result in this:

```
Press any key to continue...
q
You pressed the 'Q' key!
```

## Bug fix
Changed `WriteLineWait()` overload to return `ConsoleKeyInfo` instead of `void`.